### PR TITLE
Feat/forwarder contract

### DIFF
--- a/contracts/forwarder/Forwarder.sol
+++ b/contracts/forwarder/Forwarder.sol
@@ -6,43 +6,43 @@ pragma solidity ^0.8.27;
  * @dev A contract that forwards received Ether to a specified address
  */
 contract EtherForwarder {
-
     error ZeroAddress();
     error ForwardFailed();
     error UseForwardFunction();
-    
+
     /**
      * @dev Forwards the received Ether to the specified destination address
      * @param destination The address to forward the Ether to
      */
     function forward(address destination) external payable {
         if (destination == address(0)) revert ZeroAddress();
-        
+
         // Forward the Ether using assembly
         bool success;
         assembly {
             // Gas-efficient way to forward ETH
-            success := call(
-                gas(),      // Forward all available gas
-                destination,// Destination address
-                callvalue(),// Amount of ETH to send
-                0,         // No data to send
-                0,         // No data size
-                0,         // No data to receive
-                0          // No data size to receive
-            )
+            success :=
+                call(
+                    gas(), // Forward all available gas
+                    destination, // Destination address
+                    callvalue(), // Amount of ETH to send
+                    0, // No data to send
+                    0, // No data size
+                    0, // No data to receive
+                    0 // No data size to receive
+                )
         }
-        
+
         if (!success) revert ForwardFailed();
     }
-    
+
     /**
      * @dev Prevents accidental Ether transfers without a destination
      */
     receive() external payable {
         revert("Use forward() function to send Ether");
     }
-    
+
     /**
      * @dev Prevents accidental Ether transfers without a destination
      */

--- a/contracts/libraries/fusion/EcdsaValidatorLib.sol
+++ b/contracts/libraries/fusion/EcdsaValidatorLib.sol
@@ -65,7 +65,7 @@ library EcdsaValidatorLib {
         if (!MerkleProof.verify(proof, superTxHash, hash)) {
             return false;
         }
-        
+
         return true;
     }
 }

--- a/contracts/validators/K1MeeValidator.sol
+++ b/contracts/validators/K1MeeValidator.sol
@@ -2,11 +2,8 @@
 
 pragma solidity ^0.8.27;
 
-import {
-    IValidator,
-    MODULE_TYPE_VALIDATOR
-} from "../interfaces/IERC7579Module.sol";
-import { ERC7739Validator } from "erc7739Validator/ERC7739Validator.sol";
+import {IValidator, MODULE_TYPE_VALIDATOR} from "../interfaces/IERC7579Module.sol";
+import {ERC7739Validator} from "erc7739Validator/ERC7739Validator.sol";
 
 // Fusion libraries - validate userOp using on-chain tx or off-chain permit
 import {EnumerableSet} from "../libraries/storage/EnumerableSet4337.sol";


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new contract `EtherForwarder` for forwarding Ether, while also making minor adjustments to import statements in `K1MeeValidator.sol` and some cleanup in `EcdsaValidatorLib.sol`.

### Detailed summary
- Added `EtherForwarder` contract with functionalities to forward Ether and prevent accidental transfers.
- Introduced custom errors: `ZeroAddress`, `ForwardFailed`, and `UseForwardFunction`.
- Updated import statements in `K1MeeValidator.sol` for consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->