### PR TITLE
[Composability] Forward native value from Composability module (Issue #6)

### DIFF
--- a/contracts/composability/ComposableExecutionModule.sol
+++ b/contracts/composability/ComposableExecutionModule.sol
@@ -57,7 +57,7 @@ contract ComposableExecutionModule is IComposableExecution, IExecutor, ERC7579Fa
             bytes memory composedCalldata = execution.inputParams.processInputs(execution.functionSig);
             bytes[] memory returnData; 
             if (execution.to != address(0)) {
-                returnData = IERC7579Account(msg.sender).executeFromExecutor({
+                returnData = IERC7579Account(msg.sender).executeFromExecutor{value:execution.value}({
                     mode: ModeLib.encodeSimpleSingle(),
                     executionCalldata: ExecutionLib.encodeSingle(execution.to, execution.value, composedCalldata)
                 });


### PR DESCRIPTION
Fix [issue #6](https://github.com/zenith-security/2025-03-biconomy/issues/6)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the execution of a function within the `ComposableExecutionModule` smart contract to include a value parameter when calling the `executeFromExecutor` method.

### Detailed summary
- Updated the call to `executeFromExecutor` by adding a `value` parameter: 
  - Changed from `returnData = IERC7579Account(msg.sender).executeFromExecutor({` 
  - To `returnData = IERC7579Account(msg.sender).executeFromExecutor{value:execution.value}({`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->