### PR TITLE
[Composability] Fix: do not expect msg value

### DIFF
--- a/contracts/composability/ComposableExecutionBase.sol
+++ b/contracts/composability/ComposableExecutionBase.sol
@@ -9,8 +9,8 @@ abstract contract ComposableExecutionBase is IComposableExecution {
     using ComposableExecutionLib for InputParam[];
     using ComposableExecutionLib for OutputParam[];
 
-    /// @dev Feel free to override it to introduce additional access control or other checks
-    function executeComposable(ComposableExecution[] calldata executions) external payable virtual;
+    /// @dev Override it in the account and introduce additional access control or other checks
+    function executeComposable(ComposableExecution[] calldata executions) external virtual;
 
     /// @dev internal function to execute the composable execution flow
     /// First, processes the input parameters and returns the composed calldata

--- a/contracts/composability/ComposableExecutionModule.sol
+++ b/contracts/composability/ComposableExecutionModule.sol
@@ -35,7 +35,7 @@ contract ComposableExecutionModule is IComposableExecutionModule, IExecutor, ERC
      * @notice Executes a composable transaction with dynamic parameter composition and return value handling
      * @dev As per ERC-7579 account MUST append original msg.sender address to the calldata in a way specified by ERC-2771
      */
-    function executeComposable(ComposableExecution[] calldata executions) external payable {
+    function executeComposable(ComposableExecution[] calldata executions) external {
         // access control
         address sender = _msgSender();
         // in most cases, only first condition (against constant) will be checked
@@ -50,13 +50,12 @@ contract ComposableExecutionModule is IComposableExecutionModule, IExecutor, ERC
     /// @notice It doesn't require access control as it is expected to be called by the account itself via .execute()
     /// @dev !!! Attention !!! This function should NEVER be installed to be used via fallback() as it doesn't implement access control
     /// thus it will be callable by any address account.executeComposableCall => fallback() => this.executeComposableCall
-    /// @dev should be called by the account itself via .execute()
-    function executeComposableCall(ComposableExecution[] calldata executions) external payable { 
+    function executeComposableCall(ComposableExecution[] calldata executions) external { 
         _executeComposable(executions, msg.sender, _executeExecutionCall);
     }
 
     /// @notice It doesn't require access control as it is expected to be called by the account itself via .execute(mode = delegatecall)
-    function executeComposableDelegateCall(ComposableExecution[] calldata executions) external payable {
+    function executeComposableDelegateCall(ComposableExecution[] calldata executions) external {
         _executeComposable(executions, address(this), _executeExecutionDelegatecall);
     }
 

--- a/contracts/composability/ComposableExecutionModule.sol
+++ b/contracts/composability/ComposableExecutionModule.sol
@@ -8,7 +8,7 @@ import {ExecutionLib} from "erc7579/lib/ExecutionLib.sol";
 import {ERC7579FallbackBase} from "@rhinestone/module-bases/src/ERC7579FallbackBase.sol";
 import {IComposableExecutionModule} from "contracts/interfaces/IComposableExecution.sol";
 import {ComposableExecutionLib} from "contracts/composability/ComposableExecutionLib.sol";
-import {InputParam, OutputParam, ComposableExecution} from "contracts/types/ComposabilityDataTypes.sol";
+import {InputParam, OutputParam, ComposableExecution, Constraint, ConstraintType, InputParamFetcherType, OutputParamFetcherType} from "contracts/types/ComposabilityDataTypes.sol";
 
 /**
  * @title Composable Execution Module: Executor and Fallback
@@ -23,7 +23,6 @@ contract ComposableExecutionModule is IComposableExecutionModule, IExecutor, ERC
     using ComposableExecutionLib for OutputParam[];
 
     error OnlyEntryPointOrAccount();
-    error InsufficientMsgValue();
     error ZeroAddressNotAllowed();
     /// @notice Mapping of smart account addresses to the EP address
     mapping(address => address) private entryPoints;
@@ -72,14 +71,11 @@ contract ComposableExecutionModule is IComposableExecutionModule, IExecutor, ERC
         // we can not use erc-7579 batch mode here because we may need to compose
         // the next call in the batch based on the execution result of the previous call
         uint256 length = executions.length;
-        uint256 aggregateValue;
         for (uint256 i; i < length; i++) {
             ComposableExecution calldata execution = executions[i];
             bytes memory composedCalldata = execution.inputParams.processInputs(execution.functionSig);
             bytes[] memory returnData; 
             if (execution.to != address(0)) {
-                aggregateValue += execution.value;
-                require(msg.value >= aggregateValue, InsufficientMsgValue());
                 returnData = executeExecutionFunction(execution, composedCalldata);
             } else {
                 returnData = new bytes[](1);
@@ -87,12 +83,11 @@ contract ComposableExecutionModule is IComposableExecutionModule, IExecutor, ERC
             }
             execution.outputParams.processOutputs(returnData[0], account);
         }
-        _refundExcessValue(aggregateValue);
     }
 
     /// @dev function to be used as an argument for _executeComposable in case of regular call
     function _executeExecutionCall(ComposableExecution calldata execution, bytes memory composedCalldata) internal returns (bytes[] memory) {
-        return IERC7579Account(msg.sender).executeFromExecutor{value: execution.value}({
+        return IERC7579Account(msg.sender).executeFromExecutor({
                     mode: ModeLib.encodeSimpleSingle(),
                     executionCalldata: ExecutionLib.encodeSingle(execution.to, execution.value, composedCalldata)
                 });
@@ -141,20 +136,6 @@ contract ComposableExecutionModule is IComposableExecutionModule, IExecutor, ERC
     /// @dev Reports that this module is an executor and a fallback module
     function isModuleType(uint256 moduleTypeId) external pure override returns (bool) {
         return moduleTypeId == TYPE_EXECUTOR || moduleTypeId == TYPE_FALLBACK;
-    }
-
-    function _refundExcessValue(uint256 aggregateValue) internal {
-        assembly {
-            if gt(callvalue(), aggregateValue) {
-                let ptr := mload(0x40)
-                let excess := sub(callvalue(), aggregateValue)
-                let success := call(gas(), caller(), excess, 0, 0, ptr, returndatasize())
-                if iszero(success) {
-                    revert(ptr, returndatasize())
-                }
-                mstore(0x40, add(ptr, returndatasize()))
-            }
-        }
     }
 
     /// @notice Executes a call to a target address with specified value and data.

--- a/contracts/composability/ComposableExecutionModule.sol
+++ b/contracts/composability/ComposableExecutionModule.sol
@@ -50,6 +50,7 @@ contract ComposableExecutionModule is IComposableExecutionModule, IExecutor, ERC
     /// @notice It doesn't require access control as it is expected to be called by the account itself via .execute()
     /// @dev !!! Attention !!! This function should NEVER be installed to be used via fallback() as it doesn't implement access control
     /// thus it will be callable by any address account.executeComposableCall => fallback() => this.executeComposableCall
+    /// @dev should be called by the account itself via .execute()
     function executeComposableCall(ComposableExecution[] calldata executions) external payable { 
         _executeComposable(executions, msg.sender, _executeExecutionCall);
     }

--- a/contracts/interfaces/IComposableExecution.sol
+++ b/contracts/interfaces/IComposableExecution.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.8.23;
 import {ComposableExecution} from "../types/ComposabilityDataTypes.sol";
 
 interface IComposableExecution {
-    function executeComposable(ComposableExecution[] calldata executions) external payable;
+    function executeComposable(ComposableExecution[] calldata executions) external;
 }
 
 interface IComposableExecutionModule is IComposableExecution {
-    function executeComposableCall(ComposableExecution[] calldata executions) external payable;
-    function executeComposableDelegateCall(ComposableExecution[] calldata executions) external payable;
+    function executeComposableCall(ComposableExecution[] calldata executions) external;
+    function executeComposableDelegateCall(ComposableExecution[] calldata executions) external;
 }

--- a/test/ComposabilityBase.t.sol
+++ b/test/ComposabilityBase.t.sol
@@ -37,5 +37,12 @@ contract ComposabilityTestBase is BaseTest {
 
         mockAccount = deployMockAccount({validator: address(0), handler: address(0xa11ce)});
         mockAccountNonRevert = new MockAccountNonRevert({_validator: address(0), _handler: address(0xa11ce)});
+
+        // fund accounts
+        vm.deal(address(mockAccountFallback), 100 ether);
+        vm.deal(address(mockAccountDelegateCaller), 100 ether);
+        vm.deal(address(mockAccountCaller), 100 ether);
+        vm.deal(address(mockAccountNonRevert), 100 ether);
+        vm.deal(address(mockAccount), 100 ether);
     }
 }

--- a/test/mock/MockAccount.sol
+++ b/test/mock/MockAccount.sol
@@ -66,7 +66,7 @@ contract MockAccount is ComposableExecutionBase, IAccount {
         (success, result) = to.call{value: value}(data);
     }
 
-    function executeComposable(ComposableExecution[] calldata executions) external payable override {
+    function executeComposable(ComposableExecution[] calldata executions) external override {
         require(msg.sender == ENTRY_POINT_V07 || msg.sender == address(this), OnlyEntryPointOrSelf());
         _executeComposable(executions);
     }

--- a/test/mock/MockAccountCaller.sol
+++ b/test/mock/MockAccountCaller.sol
@@ -37,8 +37,8 @@ contract MockAccountCaller is IAccount {
     // naming is to make testing easier.
     // in the wild it should be some open execution function used instead.
     // For example ERC-7579 `execute(mode, executionData)`
-    function executeComposable(ComposableExecution[] calldata executions) external payable {
-        IComposableExecutionModule(address(handler)).executeComposableCall{value: msg.value}(executions);
+    function executeComposable(ComposableExecution[] calldata executions) external {
+        IComposableExecutionModule(address(handler)).executeComposableCall(executions);
     }
 
     function validateUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash, uint256 missingAccountFunds)

--- a/test/mock/MockAccountDelegateCaller.sol
+++ b/test/mock/MockAccountDelegateCaller.sol
@@ -12,7 +12,7 @@ contract MockAccountDelegateCaller {
         composableModule = _composableModule;
     }
 
-    function executeComposable(ComposableExecution[] calldata executions) external payable {
+    function executeComposable(ComposableExecution[] calldata executions) external {
         // delegatecall to the composableModule
         (bool success, bytes memory returnData) = composableModule.delegatecall(abi.encodeWithSelector(IComposableExecutionModule.executeComposableDelegateCall.selector, executions));
         emit MockAccountDelegateCall(returnData);

--- a/test/mock/MockAccountNonRevert.sol
+++ b/test/mock/MockAccountNonRevert.sol
@@ -65,7 +65,7 @@ contract MockAccountNonRevert is ComposableExecutionBase, IAccount {
         (success, result) = to.call{value: value}(data);
     }
 
-    function executeComposable(ComposableExecution[] calldata executions) external payable override {
+    function executeComposable(ComposableExecution[] calldata executions) external override {
         require(msg.sender == ENTRY_POINT_V07 || msg.sender == address(this), OnlyEntryPointOrSelf());
         _executeComposable(executions);
     }

--- a/test/unit/ComposableExecution.t.sol
+++ b/test/unit/ComposableExecution.t.sol
@@ -550,10 +550,8 @@ contract ComposableExecutionTest is ComposabilityTestBase {
         emit Uint256Emitted(1);
         if (address(account) == address(mockAccountFallback)) {
             emit Received(valueToSendExecution);
-            vm.expectEmit(address(mockAccountFallback));
-            emit MockAccountReceive(valueToSendExecution);
         }
-        IComposableExecution(address(account)).executeComposable{value: valueToSendToComposableModule}(executions);
+        IComposableExecution(address(account)).executeComposable(executions);
 
         vm.stopPrank();
     }
@@ -682,7 +680,7 @@ contract ComposableExecutionTest is ComposabilityTestBase {
         // stake emits input params: first param is from swap, second param is from getFoo which is just input1
         emit Uint256Emitted2(expectedToStake, input1);
         emit Received(valueToSend);
-        IComposableExecution(address(account)).executeComposable{value: 2 * valueToSend}(executions);
+        IComposableExecution(address(account)).executeComposable(executions);
 
         //check storage slots
         bytes32 storedValueA = storageContract.readStorage(namespace, SLOT_A_0);


### PR DESCRIPTION
Turns out neither ComposableExecutionBase nor ComposabilityModule should NOT expect any msg.value along with the call. as it is to be triggered for example by EP in 4337 execution phase.
So no msg.value is expected, thus account is to use it’s own value

since we do verify that fallback is triggered by EP (or account itself, still via trusted call) then fallback should just commant the accoun to use its own funds

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing the `payable` modifier from several `executeComposable` functions across various contracts, streamlining the execution process. It also includes funding accounts in tests and adjusts related function calls to ensure compatibility.

### Detailed summary
- Removed `payable` modifier from `executeComposable` in:
  - `MockAccount.sol`
  - `MockAccountNonRevert.sol`
  - `MockAccountCaller.sol`
  - `IComposableExecution` interface
  - `IComposableExecutionModule` interface
  - `ComposableExecutionModule`
- Updated calls to `executeComposable` to remove `{value: msg.value}` in tests.
- Added funding for multiple mock accounts in `ComposableExecution.t.sol`.
- Adjusted internal logic in `ComposableExecutionBase` and `ComposableExecutionModule` to manage execution without relying on `msg.value`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->