### PR TITLE
Add Paymaster factory for Nodes

### DIFF
--- a/contracts/BaseNodePaymaster.sol
+++ b/contracts/BaseNodePaymaster.sol
@@ -33,8 +33,8 @@ abstract contract BaseNodePaymaster is BasePaymaster {
     error Disabled();
     error PostOpGasLimitTooLow();
 
-    constructor(IEntryPoint _entryPoint, address _meeNodeAddress) payable BasePaymaster(_entryPoint) {
-        _transferOwnership(_meeNodeAddress);
+    constructor(IEntryPoint _entryPoint, address _meeNodeMasterEOA) payable BasePaymaster(_entryPoint) {
+        _transferOwnership(_meeNodeMasterEOA);
     }
 
     /**

--- a/contracts/NodePaymaster.sol
+++ b/contracts/NodePaymaster.sol
@@ -17,10 +17,10 @@ contract NodePaymaster is BaseNodePaymaster {
 
     constructor(
         IEntryPoint _entryPoint,
-        address _meeNodeAddress
+        address _meeNodeMasterEOA
     ) 
         payable 
-        BaseNodePaymaster(_entryPoint, _meeNodeAddress)
+        BaseNodePaymaster(_entryPoint, _meeNodeMasterEOA)
     {}
 
     /**

--- a/contracts/util/NodePaymasterFactory.sol
+++ b/contracts/util/NodePaymasterFactory.sol
@@ -20,25 +20,25 @@ contract NodePaymasterFactory {
         address expectedPm = _predictNodePaymasterAddress(entryPoint, owner, index);
 
         bytes memory deploymentData = abi.encodePacked(
-                type(NodePaymaster).creationCode,
-                abi.encode(entryPoint, owner)
-            );
+            type(NodePaymaster).creationCode,
+            abi.encode(entryPoint, owner)
+        );
 
-            assembly {
-                nodePaymaster := create2(
-                    0x0,
-                    add(0x20, deploymentData),
-                    mload(deploymentData),
-                    index
-                )
-            }
-            
-            if(address(nodePaymaster) == address(0) || address(nodePaymaster) != expectedPm) {
-                revert NodePMDeployFailed();
-            }
+        assembly {
+            nodePaymaster := create2(
+                0x0,
+                add(0x20, deploymentData),
+                mload(deploymentData),
+                index
+            )
+        }
+        
+        if(address(nodePaymaster) == address(0) || address(nodePaymaster) != expectedPm) {
+            revert NodePMDeployFailed();
+        }
 
-            // deposit the msg.value to the EP at the node paymaster's name
-            IEntryPoint(entryPoint).depositTo{value: msg.value}(nodePaymaster);
+        // deposit the msg.value to the EP at the node paymaster's name
+        IEntryPoint(entryPoint).depositTo{value: msg.value}(nodePaymaster);
     }
 
     /// @notice Get the counterfactual address of a NodePaymaster

--- a/contracts/util/NodePaymasterFactory.sol
+++ b/contracts/util/NodePaymasterFactory.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {NodePaymaster} from "contracts/NodePaymaster.sol";
+import {IEntryPoint} from "account-abstraction/interfaces/IEntryPoint.sol";
+
+contract NodePaymasterFactory {
+
+    /// @notice The error thrown when the NodePaymaster deployment fails
+    error NodePMDeployFailed();
+
+    /// @notice Deploy and fund a new NodePaymaster
+    /// @param entryPoint The 4337 EntryPoint address expected to call the NodePaymaster
+    /// @param owner The owner of the NodePaymaster
+    /// @param index The deployment index of the NodePaymaster
+    /// @return nodePaymaster The address of the deployed NodePaymaster
+    /// @dev The NodePaymaster is deployed using create2 with a deterministic address
+    /// @dev The NodePaymaster is funded with the msg.value
+    function deployAndFundNodePaymaster(address entryPoint, address owner, uint256 index) public payable returns (address nodePaymaster) {
+        address expectedPm = _predictNodePaymasterAddress(entryPoint, owner, index);
+
+        bytes memory deploymentData = abi.encodePacked(
+                type(NodePaymaster).creationCode,
+                abi.encode(entryPoint, owner)
+            );
+
+            assembly {
+                nodePaymaster := create2(
+                    0x0,
+                    add(0x20, deploymentData),
+                    mload(deploymentData),
+                    index
+                )
+            }
+            
+            if(address(nodePaymaster) == address(0) || address(nodePaymaster) != expectedPm) {
+                revert NodePMDeployFailed();
+            }
+
+            // deposit the msg.value to the EP at the node paymaster's name
+            IEntryPoint(entryPoint).depositTo{value: msg.value}(nodePaymaster);
+    }
+
+    /// @notice Get the counterfactual address of a NodePaymaster
+    /// @param entryPoint The 4337 EntryPoint address expected to call the NodePaymaster
+    /// @param owner The owner of the NodePaymaster
+    /// @param index The deployment index of the NodePaymaster
+    /// @return nodePaymaster The counterfactual address of the NodePaymaster
+    function getNodePaymasterAddress(address entryPoint, address owner, uint256 index) public view returns (address) {
+        return _predictNodePaymasterAddress(entryPoint, owner, index);
+    }
+
+    // function to check if some EOA got PmContract deployed
+    function _predictNodePaymasterAddress(address entryPoint, address owner, uint256 index) internal view returns (address) {
+        bytes32 initCodeHash =
+                keccak256(abi.encodePacked(
+                    type(NodePaymaster).creationCode, 
+                    abi.encode(entryPoint, owner)
+                ));
+
+        // Return the predicted address
+        return payable(address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), address(this), index, initCodeHash))))));
+    }
+
+}

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -30,6 +30,7 @@ import {
 } from "contracts/lib/fusion/PermitValidatorLib.sol";
 import {LibRLP} from "solady/utils/LibRLP.sol";
 
+address constant ENTRYPOINT_V07_ADDRESS = 0x0000000071727De22E5E9d8BAf0edAc6f37da032;
 
 contract BaseTest is Test {
     struct TestTemps {
@@ -55,7 +56,6 @@ contract BaseTest is Test {
     using LibZip for bytes;
     using LibRLP for LibRLP.List;
 
-    address constant ENTRYPOINT_V07_ADDRESS = 0x0000000071727De22E5E9d8BAf0edAc6f37da032;
     uint256 constant MEE_NODE_HEX = 0x177ee170de;
 
     address constant MEE_NODE_EXECUTOR_EOA = address(0xa11cebeefb0bdecaf0);

--- a/test/unit/node-paymaster/NodePaymasterFactory.t.sol
+++ b/test/unit/node-paymaster/NodePaymasterFactory.t.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {Test, Vm} from "forge-std/Test.sol";
+import {NodePaymasterFactory} from "../../../contracts/util/NodePaymasterFactory.sol";
+import {BaseTest, ENTRYPOINT_V07_ADDRESS} from "../../Base.t.sol";
+import {IEntryPoint} from "account-abstraction/interfaces/IEntryPoint.sol";
+
+contract NodePaymasterFactoryTest is BaseTest {
+
+    NodePaymasterFactory factory;
+    Vm.Wallet private owner;
+
+    function setUp() public virtual override {
+        super.setUp();
+        factory = new NodePaymasterFactory();
+        owner = createAndFundWallet("owner", 1000 ether);
+    }
+
+    function test_deployAndFundNodePaymaster_Success() public {
+        address expectedPm = factory.getNodePaymasterAddress(ENTRYPOINT_V07_ADDRESS, owner.addr, 0);
+
+        uint256 codeSize = expectedPm.code.length;
+        assertEq(codeSize, 0);
+        
+        address nodePaymaster = factory.deployAndFundNodePaymaster{value: 1 ether}(ENTRYPOINT_V07_ADDRESS, owner.addr, 0);
+        assertEq(nodePaymaster, expectedPm);
+
+        uint256 deposit = IEntryPoint(ENTRYPOINT_V07_ADDRESS).getDepositInfo(nodePaymaster).deposit;
+        assertEq(deposit, 1 ether);
+    }
+
+    
+
+}
+
+    


### PR DESCRIPTION
Deploy and fund new PM with one call

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `NodePaymaster` and `BaseNodePaymaster` contracts to improve the naming conventions and add a new `NodePaymasterFactory` for deploying and funding `NodePaymaster` instances.

### Detailed summary
- Renamed parameter `_meeNodeAddress` to `_meeNodeMasterEOA` in `NodePaymaster` and `BaseNodePaymaster` constructors.
- Updated ownership transfer in `BaseNodePaymaster` to use `_meeNodeMasterEOA`.
- Added `NodePaymasterFactory` contract for deploying and funding `NodePaymaster`.
- Implemented `deployAndFundNodePaymaster` function in `NodePaymasterFactory`.
- Introduced `getNodePaymasterAddress` function for counterfactual address retrieval.
- Added error handling for deployment failures in `NodePaymasterFactory`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->