### PR TITLE
fix: isContract => is notEOA

### DIFF
--- a/contracts/validators/K1MeeValidator.sol
+++ b/contracts/validators/K1MeeValidator.sol
@@ -56,7 +56,7 @@ contract K1MeeValidator is IValidator, ISessionValidator, ERC7739Validator {
     error ModuleAlreadyInitialized();
 
     /// @notice Error to indicate that the new owner cannot be a contract address
-    error NewOwnerIsContract();
+    error NewOwnerIsNotEOA();
 
     /// @notice Error to indicate that the owner cannot be the zero address
     error OwnerCannotBeZeroAddress();
@@ -81,7 +81,9 @@ contract K1MeeValidator is IValidator, ISessionValidator, ERC7739Validator {
         require(!_isInitialized(msg.sender), ModuleAlreadyInitialized());
         address newOwner = address(bytes20(data[:20]));
         require(newOwner != address(0), OwnerCannotBeZeroAddress());
-        require(!_isContract(newOwner), NewOwnerIsContract());
+        if (_isNotEOA(newOwner)) {
+            revert NewOwnerIsNotEOA();
+        }
         smartAccountOwners[msg.sender] = newOwner;
         if (data.length > 20) {
             _fillSafeSenders(data[20:]);
@@ -100,7 +102,9 @@ contract K1MeeValidator is IValidator, ISessionValidator, ERC7739Validator {
     /// @param newOwner The address of the new owner
     function transferOwnership(address newOwner) external {
         require(newOwner != address(0), ZeroAddressNotAllowed());
-        require(!_isContract(newOwner), NewOwnerIsContract());
+        if (_isNotEOA(newOwner)) {
+            revert NewOwnerIsNotEOA();
+        }
         smartAccountOwners[msg.sender] = newOwner;
     }
 
@@ -295,12 +299,13 @@ contract K1MeeValidator is IValidator, ISessionValidator, ERC7739Validator {
     /// @notice Checks if the address is a contract
     /// @param account The address to check
     /// @return True if the address is a contract, false otherwise
-    function _isContract(address account) private view returns (bool) {
+    function _isNotEOA(address account) private view returns (bool) {
         uint256 size;
         assembly {
             size := extcodesize(account)
         }
-        return size > 0;
+        // has code and is not delegated via eip-7702
+        return (size > 0) && (size != 23);
     }
 
     /// @dev Returns whether the `hash` and `signature` are valid.


### PR DESCRIPTION
Account for EIP-7702 case, where having code at address not certainly means it is a contract

https://github.com/zenith-security/2025-04-biconomy/issues/1

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the error handling for ownership transfer in the `K1MeeValidator` contract by changing the error message when a new owner is a contract address to be more descriptive and by renaming the related function to clarify its purpose.

### Detailed summary
- Renamed error from `NewOwnerIsContract()` to `NewOwnerIsNotEOA()`.
- Updated the ownership transfer checks to use the new error for non-EOA addresses.
- Changed the `_isContract` function to `_isNotEOA` and modified its logic to differentiate between contract addresses and externally owned accounts (EOAs).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->