### PR TITLE
fix: add sanity check before refund calculation

### DIFF
--- a/contracts/BaseNodePaymaster.sol
+++ b/contracts/BaseNodePaymaster.sol
@@ -221,8 +221,10 @@ abstract contract BaseNodePaymaster is BasePaymaster {
         actualGasCost += postOpGasLimit * actualUserOpFeePerGas;
 
         // when premium is fixed, payment by superTxn sponsor is maxGasCost + fixedPremium
-        // so we refund just the gas difference, while fixedPremium is going to the MEE Node    
-        refund = maxGasCost - actualGasCost;
+        // so we refund just the gas difference, while fixedPremium is going to the MEE Node
+        if (actualGasCost < maxGasCost) {
+            refund = maxGasCost - actualGasCost;
+        }
     }
 
     function _handlePercentagePremium(


### PR DESCRIPTION
https://github.com/zenith-security/2025-04-biconomy/issues/3

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the refund calculation logic in the `BaseNodePaymaster` contract to ensure that a refund is only computed when the `actualGasCost` is less than the `maxGasCost`, preventing unnecessary refunds.

### Detailed summary
- Added a conditional check to only calculate `refund` when `actualGasCost` is less than `maxGasCost`.
- The refund is now determined by the difference between `maxGasCost` and `actualGasCost` if the condition is met.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->