### PR TITLE
feat: node eoa master => userOp.pmAndData

### DIFF
--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -177,7 +177,7 @@ contract BaseTest is Test {
         )));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(nodeMaster.privateKey, hashToSign);
         bytes memory nodeMasterSig = abi.encodePacked(r, s, v);
-        userOp.signature = abi.encodePacked(userOp.signature, nodeMasterSig);
+        userOp.paymasterAndData = abi.encodePacked(userOp.paymasterAndData, nodeMasterSig);
         return userOp;
     }
 

--- a/test/unit/node-paymaster/NodePMAccessControl.t.sol
+++ b/test/unit/node-paymaster/NodePMAccessControl.t.sol
@@ -132,7 +132,7 @@ contract NodePMAccessControlTest is BaseTest {
             callGasLimit: 100e3
         });
 
-        uint128 pmValidationGasLimit = 35_000;
+        uint128 pmValidationGasLimit = 27_000;
         uint128 pmPostOpGasLimit = 20_000;
         uint256 maxGasLimit = userOp.preVerificationGas + unpackVerificationGasLimitMemory(userOp)
             + unpackCallGasLimitMemory(userOp) + pmValidationGasLimit + pmPostOpGasLimit;

--- a/test/unit/node-paymaster/NodePMAccessControl.t.sol
+++ b/test/unit/node-paymaster/NodePMAccessControl.t.sol
@@ -132,7 +132,7 @@ contract NodePMAccessControlTest is BaseTest {
             callGasLimit: 100e3
         });
 
-        uint128 pmValidationGasLimit = 25_000;
+        uint128 pmValidationGasLimit = 35_000;
         uint128 pmPostOpGasLimit = 20_000;
         uint256 maxGasLimit = userOp.preVerificationGas + unpackVerificationGasLimitMemory(userOp)
             + unpackCallGasLimitMemory(userOp) + pmValidationGasLimit + pmPostOpGasLimit;


### PR DESCRIPTION
- userOp hash is rehashed with the worker eoa address as previously
- Node master EOA signs this hash.
- This node master EOA sig is appended to `userOp.paymasterAndData`
- Nexus signer signs this altered userOp
- in `NodePaymaster.validatePaymasterUserOp`, the Master EOA sig is taken from the `userOp.paymasterAndData` and userOp is rehashed together with the worker eoa address
- Master EOA sig is validated against this og hash
- In all other cases (validator modules) the hash of the altered userOp is validated

