### PR TITLE
fix: [M-01] struct encoding

### DIFF
--- a/contracts/lib/util/HashLib.sol
+++ b/contracts/lib/util/HashLib.sol
@@ -100,9 +100,8 @@ library HashLib {
                 structHash = EfficientHashLib.hash(outerTypeHash, encodedData);
             } else {
                 // if SuperTx is a struct, then encoded data is just the concat of all the itemHashes
-                bytes memory encodedData = abi.encode(itemHashes);
                 /// forge-lint:disable-next-line(asm-keccak256)
-                structHash = keccak256(abi.encodePacked(outerTypeHash, encodedData));
+                structHash = keccak256(abi.encodePacked(outerTypeHash, itemHashes));
             }
             finalHash = hashTypedDataForAccount(msg.sender, structHash);
         }

--- a/test/unit/mee-k1-validator/simple-mode/MeeK1Validator_Simple_Mode_Test.t.sol
+++ b/test/unit/mee-k1-validator/simple-mode/MeeK1Validator_Simple_Mode_Test.t.sol
@@ -361,8 +361,7 @@ contract MeeK1Validator_Simple_Mode_Test is MeeK1Validator_Base_Test {
         // As per EIP-712: hashStruct(s) = keccak256(typeHash ‖ encodeData(s))
         // For a struct with multiple entries: encodeData(s) = encode(value1, value2, ..., valueN)
         // Since all our values are bytes32 hashes, we concatenate them
-        bytes memory encodedData = abi.encode(stxItemHashes);
-        bytes32 structHash = keccak256(abi.encodePacked(stxStructTypeHash, encodedData));
+        bytes32 structHash = keccak256(abi.encodePacked(stxStructTypeHash, stxItemHashes));
 
         // Now wrap with domain separator as per EIP-712: "\x19\x01" ‖ domainSeparator ‖ hashStruct(message)
         bytes32 superTxEip712Hash = HashLib.hashTypedDataForAccount(smartAccount, structHash);


### PR DESCRIPTION
fixes [M-01](https://github.com/PashovAuditGroup/Biconomy_October25_MERGED/issues/2) 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing the encoding of data for struct hashing in the `HashLib` contract and related tests. It simplifies the process by directly using `itemHashes` instead of an intermediate `encodedData` variable.

### Detailed summary
- In `HashLib.sol`, `encodedData` variable is removed; `structHash` now uses `itemHashes` directly.
- In `MeeK1Validator_Simple_Mode_Test.t.sol`, `encodedData` variable is removed; `structHash` now uses `stxItemHashes` directly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->