### PR TITLE
Fix [L-03] Domain separator prevents cross-chain SuperTransaction signatures

### DIFF
--- a/.github/workflows/foundry-test.yml
+++ b/.github/workflows/foundry-test.yml
@@ -39,6 +39,6 @@ jobs:
       run: pnpm install --frozen-lockfile
     
     - name: Run Forge tests
-      run: forge test --isolate
+      run: forge test --isolate --threads 1
       env:
         FOUNDRY_PROFILE: ci

--- a/contracts/lib/util/HashLib.sol
+++ b/contracts/lib/util/HashLib.sol
@@ -20,9 +20,8 @@ interface IERC5267 {
 
 // keccak256("SuperTx(MeeUserOp[] meeUserOps)");
 bytes32 constant SUPER_TX_MEE_USER_OP_ARRAY_TYPEHASH = 0x07bdf0267970db0d5b9acc9d9fa8ef0cbb5b543fb897017542bfb306f5e46ad0;
-// keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,bytes32 salt,uint256[]
-// extensions)");
-bytes32 constant _DOMAIN_TYPEHASH = 0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f;
+// keccak256("EIP712Domain(string name");
+bytes32 constant _DOMAIN_TYPEHASH = 0x95e78ac088fa46a576911187c70ccdc0642491fdb90b2ed8674182c4aabca91d;
 uint256 constant STATIC_HEAD_LENGTH = 0x80; // introduced to re-use it in the contracts that use this library
 
 library HashLib {
@@ -116,11 +115,14 @@ library HashLib {
             /*bytes1 fields*/
             ,
             string memory name,
-            string memory version,
-            uint256 chainId,
-            address verifyingContract,
-            /*bytes32 salt*/
             ,
+            ,
+            ,
+            ,
+            /* string memory version,
+            uint256 chainId,
+            address verifyingContract,*/
+            /*bytes32 salt,*/
             /*uint256[] memory extensions*/
         ) = IERC5267(account).eip712Domain();
 
@@ -130,10 +132,7 @@ library HashLib {
             let m := mload(0x40) // Load the free memory pointer.
             mstore(m, _DOMAIN_TYPEHASH)
             mstore(add(m, 0x20), keccak256(add(name, 0x20), mload(name))) // Name hash.
-            mstore(add(m, 0x40), keccak256(add(version, 0x20), mload(version))) // Version hash.
-            mstore(add(m, 0x60), chainId)
-            mstore(add(m, 0x80), verifyingContract)
-            digest := keccak256(m, 0xa0) //domain separator
+            digest := keccak256(m, 0x40) //domain separator
 
             // Hash typed data
             mstore(0x00, 0x1901000000000000) // Store "\x19\x01".


### PR DESCRIPTION
Fixes this https://github.com/PashovAuditGroup/Biconomy_October25_MERGED/issues/4 

- I also removed version, since it may prevent cross-chain stx sigs as well because versions on different chains may not be consistent
- Instead of using 0 as chainId and address(0) as verifyingContract and probably 0 as version, I completely removed those fields from the separator, as perEIP-712 

> `type of eip712Domain is a struct named EIP712Domain with one or more of the below fields. Protocol designers only need to include the fields that make sense for their signing domain. Unused fields are left out of the struct type.`
https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the GitHub Actions workflow for testing and modifying the `HashLib` Solidity library by adjusting the EIP712 domain typehash and related parameters.

### Detailed summary
- Updated the workflow in `.github/workflows/foundry-test.yml` to run tests with `--threads 1`.
- Modified the `HashLib.sol` file:
  - Changed the `_DOMAIN_TYPEHASH` to a new value.
  - Removed comments and parameters related to `version`, `chainId`, and `verifyingContract` in the `eip712Domain()` function.
  - Adjusted the `keccak256` calculation for the domain separator to accommodate the changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->